### PR TITLE
Update open.dm

### DIFF
--- a/dwarfs/code/turfs/open.dm
+++ b/dwarfs/code/turfs/open.dm
@@ -112,7 +112,7 @@
 		if(I.use_tool(src, user, 10 SECONDS))
 			stop_sound_channel_nearby(src, channel)
 			var/turf/open/floor/tilled/T = ChangeTurf(/turf/open/floor/tilled)
-			if((locate(/turf/open/water) in range(1, T)))
+			if(((locate(/turf/open/water) in range(3, T))) || ((locate(/obj/structure/well) in range(3, T))))
 				T.waterlevel = T.watermax
 				T.update_appearance()
 			user.mind.adjust_experience(/datum/skill/farming, 7)
@@ -260,7 +260,7 @@
 
 /turf/open/floor/tilled/proc/on_eat(obj/structure/plant/source)
 	SIGNAL_HANDLER
-	if((locate(/turf/open/water) in range(1, src)))
+    if(((locate(/turf/open/water) in range(3, src))) || ((locate(/obj/structure/well) in range(3, src))))
 		waterlevel = watermax
 	waterlevel = clamp(waterlevel-waterrate, 0, watermax)
 	update_appearance()


### PR DESCRIPTION
Tilled dirt tiles will now stay at max water levels as long as they have a water source within 3 tiles. Currently those sources can either be an actual water tile (/turf/open/water) or a well (/obj/structure/well).